### PR TITLE
Returned an Option<String> instead of an Option<GString>

### DIFF
--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -28,7 +28,8 @@ impl Stack {
     }
 
     fn current_window(&self) -> Option<String> {
-        self.stack.get_visible_child_name()
+        let current_window_name = self.stack.get_visible_child_name();
+        return Some(current_window_name.unwrap().to_owned());
     }
 
     pub fn next_window(&self) {


### PR DESCRIPTION
Hello! 
Thanks for the repo, it is really useful. Since the "get_visible_child_name" function returns a <GString> value, I was getting an error, so I unwrapped the windows name in order to return the Option<String>.